### PR TITLE
Add Drupal 8 module Code Climate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,12 +1,21 @@
 ---
 engines:
+  phpmd:
+    enabled: true
+    config:
+      file_extensions: "php,inc,module,install"
+      rulesets: ".phpmd.xml"
   phpcodesniffer:
     enabled: true
     config:
+      file_extensions: "php,inc,module,install"
       encoding: utf-8
       standard: "Drupal"
-      ignore_warnings: false
+      ignore_warnings: true
+ratings:
+  paths:
+  - "**.php"
+  - "**.inc"
+  - "**.module"
+  - "**.install"
 exclude_paths:
-- .phpcs
-- .travis
-- tests


### PR DESCRIPTION
https://www.drupal.org/node/2808731

This PR adds a Code Climate config.

After this is added:
1. GitHub can be integrated into Code Climate to give per-PR analysis.
2. A badge showing the GPA can be generated to add to the Drupal.org project page, which will also link to the list of issues (if desired).

One controversial item: this config uses PHPMD, which is not considered Drupal standards. I have found it useful, but let me know if you'd like it removed.

A similar one is made here: https://github.com/timmillwood/drupal-workspace/pull/8
