### PR TITLE
FIX: Issue #2978796 - PouchDB replication fails for non-trivial DB

### DIFF
--- a/src/AllDocs/AllDocs.php
+++ b/src/AllDocs/AllDocs.php
@@ -67,6 +67,11 @@ class AllDocs implements AllDocsInterface {
    */
   protected $endKey;
 
+    /**
+   * @var string
+   */
+  protected $keys;
+
   /**
    * @var boolean
    */
@@ -136,6 +141,13 @@ class AllDocs implements AllDocsInterface {
     $this->inclusiveEnd = $inclusive_end;
   }
 
+    /**
+   * {@inheritdoc}
+   */
+  public function keys($keys) {
+    $this->keys = $keys;
+  }
+
   /**
    * {@inheritdoc}
    *
@@ -155,6 +167,14 @@ class AllDocs implements AllDocsInterface {
           if ($entity_type->get('workspace') !== FALSE) {
             $query->condition('workspace', $this->workspace->id());
           }
+          if($this->keys) {
+            $group = $query
+              ->orConditionGroup();
+              foreach($this->keys as $key) {
+              $group->condition('uuid', $key);
+              }
+            $query->condition($group);
+          }
           $ids = $query->execute();
         }
         catch (\Exception $e) {
@@ -169,9 +189,9 @@ class AllDocs implements AllDocsInterface {
         $items = $this->entityIndex->getMultiple($keys);
         foreach ($items as $item) {
           if ($item['is_stub'] == TRUE) {
-            continue;
-          }
-          $rows[$item['uuid']] = ['rev' => $item['rev']];
+          continue;
+        }          
+        $rows[$item['uuid']] = ['rev' => $item['rev']];
         }
 
         if ($this->includeDocs) {

--- a/src/AllDocs/AllDocsInterface.php
+++ b/src/AllDocs/AllDocsInterface.php
@@ -46,6 +46,12 @@ interface AllDocsInterface {
    */
   public function inclusiveEnd($inclusive_end);
 
+    /**
+   * @param boolean $keys
+   * @return \Drupal\replication\AllDocs\AllDocsInterface
+   */
+  public function keys($keys);
+
   /**
    * @return array
    */

--- a/src/Changes/Changes.php
+++ b/src/Changes/Changes.php
@@ -105,6 +105,13 @@ class Changes implements ChangesInterface {
    * {@inheritdoc}
    */
   public function filter($filter) {
+        //test if filter name has been turned to name/name by pouchdb/couchdb and revert to single name
+        $split = explode("/", $filter);
+        //print(count($split));
+        if(count($split) === 2 && $split[0] === $split[1]) {
+          //print_r($split);
+          $filter = $split[0];
+        }
     $this->filter = $filter;
     return $this;
   }
@@ -191,7 +198,13 @@ class Changes implements ChangesInterface {
         $storage->useWorkspace($this->workspaceId);
         $revision = $storage->loadRevision($sequence['revision_id']);
         $storage->useWorkspace(NULL);
+         // Ignore broken revisions.
+         if(!$revision) {
+          continue;
+        }
       }
+
+            
 
       // Filter the document.
       if ($revision && $filter !== NULL && !$filter->filter($revision)) {

--- a/src/Normalizer/FileEntityNormalizer.php
+++ b/src/Normalizer/FileEntityNormalizer.php
@@ -66,13 +66,15 @@ class FileEntityNormalizer extends ContentEntityNormalizer implements Denormaliz
       }
 
       // @todo {@link https://www.drupal.org/node/2600360 Add revpos and other missing properties to the result array.}
-      $normalized['@attachment'] = [
-        'uuid' => $data->uuid(),
-        'uri' => $uri,
-        'content_type' => $data->getMimeType(),
-        'digest' => 'md5-' . base64_encode(md5($file_contents)),
-        'length' => $data->getSize(),
-        'data' => $file_data,
+      $normalized['_attachments'] = [
+        '@attachment' => [
+          'uuid' => $data->uuid(),
+          'uri' => $uri,
+          'content_type' => $data->getMimeType(),
+          'digest' => 'md5-' . base64_encode(md5($file_contents)),
+          'length' => $data->getSize(),
+          'data' => $file_data,
+        ]
       ];
     }
     return $normalized;
@@ -83,11 +85,11 @@ class FileEntityNormalizer extends ContentEntityNormalizer implements Denormaliz
    */
   public function denormalize($data, $class, $format = NULL, array $context = []) {
     $file = NULL;
-    if (!empty($data['@attachment']['uuid'])) {
+    if (!empty($data['_attachments']['@attachment']['uuid'])) {
       $workspace = isset($context['workspace']) ? $context['workspace'] : NULL;
       /** @var FileInterface $file */
-      $this->processFileAttachment->process($data['@attachment'], 'base64_stream', $workspace);
-      unset($data['@attachment']);
+      $this->processFileAttachment->process($data['_attachments']['@attachment'], 'base64_stream', $workspace);
+      unset($data['_attachments']['@attachment']);
     }
     return parent::denormalize($data, $class, $format, $context);
   }
@@ -97,7 +99,7 @@ class FileEntityNormalizer extends ContentEntityNormalizer implements Denormaliz
     // File entities are treated as standard content entities.
     if (in_array($type, ['Drupal\Core\Entity\ContentEntityInterface', 'Drupal\file\FileInterface'], TRUE)) {
       // If a document has _attachment then we assume it's a file entity.
-      if (!empty($data['@attachment'])) {
+      if (!empty($data['_attachments']['@attachment'])) {
         return TRUE;
       }
     }

--- a/src/Plugin/Field/FieldType/ReplicationHistoryItem.php
+++ b/src/Plugin/Field/FieldType/ReplicationHistoryItem.php
@@ -83,6 +83,11 @@ class ReplicationHistoryItem extends FieldItemBase {
       ->setDescription(t('Date and time when replication ended.'))
       ->setRequired(FALSE);
 
+    $properties['last_seq'] = DataDefinition::create('string')
+      ->setLabel(t('Last sequence'))
+      ->setDescription(t('Used by PouchDB instead of Recorded sequence'))
+      ->setRequired(FALSE);
+
     return $properties;
   }
 
@@ -146,6 +151,11 @@ class ReplicationHistoryItem extends FieldItemBase {
           'type' => 'varchar',
           'length' => 50,
           'not null' => FALSE,
+        ],
+        'recorded_seq' => [
+          'type' => 'varchar',
+          'length' => 512,
+          'not null' => TRUE,
         ],
       ],
     ];

--- a/tests/src/Kernel/Normalizer/FileEntityNormalizerTest.php
+++ b/tests/src/Kernel/Normalizer/FileEntityNormalizerTest.php
@@ -100,7 +100,9 @@ class FileEntityNormalizerTest extends NormalizerTestBase{
           ['value' => $file->_rev->value],
         ],
       ],
-      '@attachment' => $expected_attachment,
+      '_attachments' => [
+        '@attachment' => $expected_attachment
+      ],
       '_id' => $file->uuid(),
       '_rev' => $file->_rev->value,
       '_revisions' => [


### PR DESCRIPTION
These commits add the keys parameter to AllDocs which is used by PouchDB during replication. 
It also moves attachments into the "_attachments" array so that PouchDB/CouchDB can store them correctly as binary files.
Finally, when defining a filter without a "/" in PouchDB it automatically adds the slash as ,"<name>/<name>"